### PR TITLE
Task/mthibault/KEP-651 - Heroku config autofill & URL params autofill

### DIFF
--- a/web/src/components/App.js
+++ b/web/src/components/App.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill';
+
 import {HashRouter, Route} from 'react-router-dom'
 import {Main} from 'components/Main'
 import {execute} from "../services/CommandQueueService";
@@ -28,6 +30,7 @@ export class App extends Component {
     go(ws_url, uuid) {
         
         connect(ws_url, uuid);
+
 
         keys().then(() => {
 

--- a/web/src/components/DaemonSelector/DaemonSelector.js
+++ b/web/src/components/DaemonSelector/DaemonSelector.js
@@ -4,12 +4,62 @@ import {Header} from '../Header/Header'
 const uuidv4 = require('uuid/v4');
 
 
+
+const url_params = window && new URLSearchParams(window.location.search);
+
+
+const requestObject = {
+    method: 'GET',
+    headers: {
+        'Accept': 'application/vnd.heroku+json; version=3',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer 74d54dfd-f692-410b-9d4b-3e239bb0d34f'
+    }
+}
+
+
+const getConfig = async appName => {
+
+    const response = await fetch('https://api.heroku.com/apps/' + appName + '/config-vars', requestObject);
+        
+    const json = response.json();
+
+    // json.BLUZELLEDB_PORT
+    // json.BLUZELLEDB_ADDRESS
+    // json.BLUZELLEDB_UUID
+
+    return json;
+
+};
+
+
+
 @observer
 export default class DaemonSelector extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {showConfigLoader: false};
+    }
 
     go() {
 
-        const ws_url = 'ws://' + this.address.value + ':' + this.port.value;
+        this.address.value = this.address.value || this.address.placeholder;
+        this.port.value = this.port.value || this.port.placeholder;
+        this.uuid.value = this.uuid.value || this.uuid.placeholder;
+
+
+        if(!url_params.get('app')) {
+            !url_params.get('address') && url_params.set('address', this.address.value);
+            !url_params.get('port') && url_params.set('port', this.port.value);
+            !url_params.get('uuid') && url_params.set('uuid', this.uuid.value);
+
+            const new_url_params = location.pathname + '?' + url_params.toString();
+
+            window.history.pushState('', '', new_url_params);
+        }
+
+        const ws_url = this.address.value + ':' + this.port.value;
         const uuid = this.uuid.value;
 
         this.props.go(ws_url, uuid);
@@ -21,8 +71,68 @@ export default class DaemonSelector extends Component {
 
     componentDidMount() {
         this.address.focus();
+
+
+        if(url_params) {
+
+            url_params.get('address') && (this.address.value = url_params.get('address'));
+            url_params.get('port') && (this.port.value = url_params.get('port'));
+            url_params.get('uuid') && (this.uuid.value = url_params.get('uuid'));
+
+
+            if(url_params.get('address') && url_params.get('port') && url_params.get('uuid')) {
+
+                this.go();
+                return;
+
+            }
+
+            if(url_params.get('app')) {
+
+                this.setState({showConfigLoader: true});
+
+                getConfig(url_params.get('app')).then(
+                    json => {
+
+
+                        if(!('BLUZELLEDB_ADDRESS' in json)
+                            || !('BLUZELLEDB_PORT' in json)
+                            || !('BLUZELLEDB_UUID' in json)) {
+
+                            alert('Heroku config response malformed. Check console.');
+                            console.log('Heroku config response malformed. Expected "BLUZELLEDB_ADDRESS", "BLUZELLEDB_PORT", "BLUZELLEDB_UUID".');
+                            console.log(json);
+
+                            this.setState({showConfigLoader: false});
+                            return;
+
+                        }
+
+                        this.setState({showConfigLoader: false});
+
+                        this.address.value = json.BLUZELLEDB_ADDRESS;
+                        this.port.value = json.BLUZELLEDB_PORT;
+                        this.uuid.value = json.BLUZELLEDB_UUID;
+
+                        this.go();
+
+                    }, 
+                    () => {
+                        alert(`Not able to fetch config parameters for app "${url_params.get('app')}".`);
+                        this.setState({showConfigLoader: false});
+                    });
+
+            }
+
+        }
+
     }
 
+    copy() {
+        this.uuid.value = this.uuid.placeholder;
+        this.uuid.select();
+        document.execCommand("copy");
+    }
 
     render() {
 
@@ -33,12 +143,16 @@ export default class DaemonSelector extends Component {
                     <BS.Card style={{marginTop: 20}} header={<h3>Choose a Bluzelle node</h3>}>
                         <div style={{width: 400, padding: 20}}>
 
+                            { this.state.showConfigLoader &&
+                                <BS.Alert color="primary">Loading config parameters from Heroku...</BS.Alert>
+                            }
+
                             <BS.Form>
 
                                 <BS.FormGroup row>
                                     <BS.Label sm={3} for="address">Address:</BS.Label>
                                     <BS.Col sm={9}>
-                                        <BS.Input type="text" name="address" placeholder="testnet.bluzelle.com" innerRef={e => {this.address = e;}}/>
+                                        <BS.Input type="text" name="address" placeholder="ws://testnet.bluzelle.com" innerRef={e => {this.address = e;}}/>
                                     </BS.Col>
                                 </BS.FormGroup>
 
@@ -52,7 +166,10 @@ export default class DaemonSelector extends Component {
                                 <BS.FormGroup row>
                                     <BS.Label sm={3} for="uuid">UUID:</BS.Label>
                                     <BS.Col sm={9}>
-                                        <BS.Input type="text" name="uuid" placeholder={uuidv4()} innerRef={e => {this.uuid = e;}}/>
+                                     <BS.InputGroup>
+                                        <BS.Input type="text" name="uuid" placeholder={uuidv4()} innerRef={e => {this.uuid = e;}} />
+                                        <BS.InputGroupAddon addonType="append"><BS.Button outline color="secondary" type="button" onClick={() => this.copy()}><i className="fas fa-copy"></i></BS.Button></BS.InputGroupAddon>
+                                      </BS.InputGroup>
                                     </BS.Col>
                                 </BS.FormGroup>
 


### PR DESCRIPTION
- If you add an "app" GET parameter (like `http://localhost:8080/?app=bluzelleherokuchat`), the app will automatically fetch the parameters from Heroku and initiate the connection.
- The app will automatically fill in the "address", "port", and "uuid" parameters. If all three are present, it will automatically initiate a connection.
- After a connection is initiated, you will have a url like `http://localhost:8080/?address=ws%3A%2F%2Ftestnet.bluzelle.com&port=51010&uuid=dee64982-bf5e-4b2b-978e-092d22f218bb` which can be refreshed to automatically reconnect.
- Initiating a connection adds a historyState in the browser, allowing you to use the back and foreward buttons.
- There's a button to copy the UUID to clipboard on the daemon selector screen.