### PR TITLE
KEP-944 - CSV Upload in BluzelleStudio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11685,6 +11685,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
+    "papaparse": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.6.3.tgz",
+      "integrity": "sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ=="
+    },
     "parse-asn1": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mocha": "^4.1.0",
     "npm": "^6.4.1",
     "nyc": "^11.2.1",
+    "papaparse": "^4.6.3",
     "path": "^0.12.7",
     "pkg-config": "^1.1.1",
     "promise-waitfor": "^2.0.0",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,19 +20,12 @@ const url_params = window && new URLSearchParams(window.location.search);
 configureDevtool({logEnabled: url_params.has('log')});
 
 
-import {createClient} from '../services/BluzelleService'
+import {createClient} from '../services/BluzelleService';
 
+export const connected = observable(false);
 
 @observer
 export class App extends Component {
-
-    componentWillMount() {
-
-        this.setState({
-            connected: false
-        });
-
-    }
 
 
     go(ws_url, uuid, pem) {
@@ -68,9 +61,7 @@ export class App extends Component {
         })
         .then(() => {
 
-            this.setState({
-                connected: true
-            });
+            connected.set(true);
 
         })
         .catch(e => {
@@ -94,7 +85,7 @@ export class App extends Component {
                 {/dev-tools/.test(window.location.href) && <DevTools/>}
 
                 {
-                    this.state.connected ?
+                    connected.get() ?
                         <Main/> :
                         <DaemonSelector go={this.go.bind(this)}/>
                 }

--- a/src/components/DaemonSelector/DaemonSelector.js
+++ b/src/components/DaemonSelector/DaemonSelector.js
@@ -5,6 +5,8 @@ import fetch from 'isomorphic-fetch';
 const uuidv4 = require('uuid/v4');
 
 
+const connecting = observable(false);
+
 
 const url_params = window && new URLSearchParams(window.location.search);
 
@@ -42,6 +44,8 @@ export default class DaemonSelector extends Component {
         const ws_url = this.address.value + ':' + this.port.value;
         const uuid = this.uuid.value;
         const pem = this.pem;
+
+        connecting.set(true);
 
         this.props.go(ws_url, uuid, pem);
     }
@@ -199,11 +203,18 @@ export default class DaemonSelector extends Component {
 
                                 <hr/>
 
-                                <div style={{marginTop: 10}}>
-                                    <BS.Button 
-                                        color="primary"
-                                        style={{width: '100%'}}
-                                        onClick={this.go.bind(this)}>Go</BS.Button>
+                                <style>{".lds-ellipsis {\r\n  display: inline-block;\r\n  position: relative;\r\n  width: 64px;\r\n  height: 7px;\r\n}\r\n.lds-ellipsis div {\r\n  position: absolute;\r\n  top: 0px;\r\n  width: 5px;\r\n  height: 5px;\r\n  border-radius: 50%;\r\n  animation-timing-function: cubic-bezier(0, 1, 1, 0);\r\n}\r\n.lds-ellipsis div:nth-child(1) {\r\n  left: 6px;\r\n  animation: lds-ellipsis1 0.6s infinite;\r\n}\r\n.lds-ellipsis div:nth-child(2) {\r\n  left: 6px;\r\n  animation: lds-ellipsis2 0.6s infinite;\r\n}\r\n.lds-ellipsis div:nth-child(3) {\r\n  left: 26px;\r\n  animation: lds-ellipsis2 0.6s infinite;\r\n}\r\n.lds-ellipsis div:nth-child(4) {\r\n  left: 45px;\r\n  animation: lds-ellipsis3 0.6s infinite;\r\n}\r\n@keyframes lds-ellipsis1 {\r\n  0% {\r\n    transform: scale(0);\r\n  }\r\n  100% {\r\n    transform: scale(1);\r\n  }\r\n}\r\n@keyframes lds-ellipsis3 {\r\n  0% {\r\n    transform: scale(1);\r\n  }\r\n  100% {\r\n    transform: scale(0);\r\n  }\r\n}\r\n@keyframes lds-ellipsis2 {\r\n  0% {\r\n    transform: translate(0, 0);\r\n  }\r\n  100% {\r\n    transform: translate(19px, 0);\r\n  }\r\n}"}</style>
+
+                                <div style={{marginTop: 10, textAlign: 'center'}}>
+
+                                    { connecting.get() === false ?
+                                        <BS.Button 
+                                            color="primary"
+                                            style={{width: '100%'}}
+                                            onClick={this.go.bind(this)}>Go</BS.Button>
+                                        :
+                                        <div className="lds-ellipsis" style={{marginTop: 15}}><div className='badge-primary'></div><div className='badge-primary'></div><div className='badge-primary'></div><div className='badge-primary'></div></div>
+                                    }
                                 </div>
 
                             </BS.Form>

--- a/src/components/KeyList/KeyList.js
+++ b/src/components/KeyList/KeyList.js
@@ -6,6 +6,8 @@ import {observe} from 'mobx';
 import {getClient, config} from '../../services/BluzelleService'
 import {Fragment} from 'react';
 import {is_writer} from '../Permissioning';
+import {importCSV} from './importCSV';
+
 
 export const selectedKey = observable(undefined);
 
@@ -98,6 +100,21 @@ export class KeyList extends Component {
                         }
 
                         <SaveReloadRemove/>
+                    </BS.ButtonGroup>
+
+                    <BS.ButtonGroup style={{ paddingLeft: 10 }}>
+                        <BS.Button
+                            outline
+                            id="importButton"
+                            color="primary"
+                            onClick={importCSV}>
+
+                            <i className="fas fa-file-import"></i>
+                        </BS.Button>
+
+                        <BS.UncontrolledTooltip placement="right" target="importButton">
+                            Import CSV file
+                        </BS.UncontrolledTooltip>
                     </BS.ButtonGroup>
                 </BS.ButtonToolbar>
             </div>

--- a/src/components/KeyList/KeyList.js
+++ b/src/components/KeyList/KeyList.js
@@ -17,7 +17,7 @@ export const keys = observable([]);
 export const refreshKeys = () => 
     getClient().keys().then(k => keys.replace(k)).catch(() => alert('Failed to fetch keys due to bluzelle network error.'));
 
-export const tempKey = observable.box();
+export const tempKeys = observable([]);
 
 
 @observer

--- a/src/components/KeyList/KeyListItem.js
+++ b/src/components/KeyList/KeyListItem.js
@@ -1,6 +1,6 @@
 import {ValIcon} from "../ObjIcon";
 import {EditableField} from "../EditableField";
-import {selectedKey, tempKey} from "./KeyList";
+import {selectedKey, tempKeys} from "./KeyList";
 import {activeValue, rename} from '../../services/CRUDService';
 
 import {execute} from '../../services/CommandQueueService';
@@ -45,20 +45,29 @@ export class KeyListItem extends Component {
             <BS.ListGroupItem
                 onClick={() => {
 
-                    if(keyname === tempKey.get()) return;
+                    if(tempKeys.includes(keyname)) return;
 
                     selectedKey.get() === keyname ? 
                         this.select(undefined) : 
                         this.select(keyname)}
 
                 }
-                active={selectedKey.get() === keyname}
-                color={keyname === tempKey.get() ? 'warning' : ''}>
-
-                <Icon keyname={keyname}/>
+                active={selectedKey.get() === keyname}>
 
 
-                <span>{keyname}</span>
+                <span style={{marginLeft: 15}}>{keyname}</span>
+
+
+                {/*Loading bar from https://loading.io/css/*/}
+
+                <style>{".lds-ellipsis {\r\n  display: inline-block;\r\n  position: relative;\r\n  width: 64px;\r\n  height: 7px;\r\n}\r\n.lds-ellipsis div {\r\n  position: absolute;\r\n  top: 0px;\r\n  width: 5px;\r\n  height: 5px;\r\n  border-radius: 50%;\r\n  animation-timing-function: cubic-bezier(0, 1, 1, 0);\r\n}\r\n.lds-ellipsis div:nth-child(1) {\r\n  left: 6px;\r\n  animation: lds-ellipsis1 0.6s infinite;\r\n}\r\n.lds-ellipsis div:nth-child(2) {\r\n  left: 6px;\r\n  animation: lds-ellipsis2 0.6s infinite;\r\n}\r\n.lds-ellipsis div:nth-child(3) {\r\n  left: 26px;\r\n  animation: lds-ellipsis2 0.6s infinite;\r\n}\r\n.lds-ellipsis div:nth-child(4) {\r\n  left: 45px;\r\n  animation: lds-ellipsis3 0.6s infinite;\r\n}\r\n@keyframes lds-ellipsis1 {\r\n  0% {\r\n    transform: scale(0);\r\n  }\r\n  100% {\r\n    transform: scale(1);\r\n  }\r\n}\r\n@keyframes lds-ellipsis3 {\r\n  0% {\r\n    transform: scale(1);\r\n  }\r\n  100% {\r\n    transform: scale(0);\r\n  }\r\n}\r\n@keyframes lds-ellipsis2 {\r\n  0% {\r\n    transform: translate(0, 0);\r\n  }\r\n  100% {\r\n    transform: translate(19px, 0);\r\n  }\r\n}"}</style>
+
+                <style>{".list-group-item.active .lds-ellipsis div { background-color: white; }"}</style>
+                
+                {
+                    tempKeys.includes(keyname) &&
+                        <div className="lds-ellipsis" style={{marginLeft: 15}}><div className='badge-primary'></div><div className='badge-primary'></div><div className='badge-primary'></div><div className='badge-primary'></div></div>
+                }
 
                 {
 
@@ -77,28 +86,3 @@ export class KeyListItem extends Component {
         );
     }
 }
-
-
-const Icon = observer(({keyname}) =>
-
-    <span style={{display: 'inline-block', width: 25}}>
-        {
-
-            activeValue.get() !== undefined &&
-            selectedKey.get() === keyname &&
-
-                <ValIcon val={activeValue.get()}/>
-                
-
-        }
-
-        {
-            keyname === tempKey.get() &&
-                <i 
-                    style={{color: 'orange'}}
-                    className="fas fa-exchange"></i>
-
-        }
-    </span>
-
-);

--- a/src/components/KeyList/NewKey/NewKeyField.js
+++ b/src/components/KeyList/NewKey/NewKeyField.js
@@ -1,5 +1,7 @@
 import {TypeModal} from "./TypeModal";
 import {EditableField} from "../../EditableField";
+import {create} from '../../../services/CRUDService';
+
 
 export class NewKeyField extends Component {
 
@@ -7,7 +9,6 @@ export class NewKeyField extends Component {
         super(props);
 
         this.state = {
-            showModal: false,
             keyField: ''
         };
     }
@@ -15,15 +16,16 @@ export class NewKeyField extends Component {
     onChange(key) {
 
         this.setState({ keyField: key });
-        isEmpty() ? this.exit() : this.showModal();
 
-        function isEmpty() {
-            return key === '';
+        if(key !== '') {
+
+            this.exit();
+
+            create(key, '');
+
         }
-    }
 
-    showModal() {
-        this.setState({ showModal: true });
+ 
     }
 
     exit() {
@@ -43,12 +45,6 @@ export class NewKeyField extends Component {
                         onChange={this.onChange.bind(this)}/>
 
                 </BS.ListGroupItem>
-
-                {this.state.showModal &&
-
-                    <TypeModal
-                        onHide={this.exit.bind(this)}
-                        keyField={this.state.keyField}/>}
 
             </React.Fragment>
 

--- a/src/components/KeyList/NewKey/TypeModal.js
+++ b/src/components/KeyList/NewKey/TypeModal.js
@@ -1,64 +1,11 @@
 import {JSONIcon, TextIcon, FileIcon} from "../../ObjIcon";
-import {selectedKey, refreshKeys, keys, tempKey} from "../KeyList";
+import {selectedKey, refreshKeys, keys, tempKeys} from "../KeyList";
 import {getClient} from '../../../services/BluzelleService';
 import {execute} from '../../../services/CommandQueueService';
+import {create} from '../../../services/CRUDService';
 
 
 export class TypeModal extends Component {
-
-    chooseJSON() {
-        this.addNewKey({}, 'JSON');
-    }
-
-    chooseText() {
-        this.addNewKey('', 'plain text');
-    }
-
-    chooseFile() {
-        this.addNewKey(new ArrayBuffer(), 'file');
-    }
-
-
-    addNewKey(keyData, typeName) {
-
-        const oldSelection = selectedKey.get();
-
-
-        execute({
-            doIt: () => new Promise(resolve => {
-
-                keys.push(this.props.keyField);
-                tempKey.set(this.props.keyField);
-
-                getClient().create(this.props.keyField, keyData).then(() => {
-                    
-                    tempKey.set();
-                    refreshKeys().then(resolve)
-
-                }).catch(() => {
-
-                    tempKey.set();
-                    keys.splice(keys.indexOf(this.props.keyField), 1);
-                    
-                    alert('Failed to create key due to bluzelle network error.'); 
-
-                });
-
-            }),
-
-            undoIt: () => new Promise(resolve => {
-
-                getClient().delete(this.props.keyField).then(() =>
-                    refreshKeys().then(resolve))
-                    .catch(() => alert('Failed to undo due to bluzelle network error.'));
-            }),
-
-            message: <span>Added field <code key={1}>{this.props.keyField}</code>.</span>
-        });
-
-        this.props.onHide();
-
-    }
 
 
     render() {
@@ -68,7 +15,7 @@ export class TypeModal extends Component {
         // Removing this re-enables the popup dialog where you
         // can choose text/JSON/file.
 
-        this.chooseText();
+        create(this.props.keyField, '');
 
 
         return (<div></div>);

--- a/src/components/KeyList/importCSV.js
+++ b/src/components/KeyList/importCSV.js
@@ -1,5 +1,6 @@
 import {getClient} from '../../services/BluzelleService'
 import Papa from 'papaparse';
+import {create} from '../../services/CRUDService';
 
 
 export const importCSV = () => {
@@ -42,7 +43,8 @@ export const importCSV = () => {
                 }));
 
 
-                console.log(fields);
+                createFields(fields);
+
 
             }
         });
@@ -52,5 +54,24 @@ export const importCSV = () => {
 
 
     input.click();
+
+};
+
+
+const createFields = async fields => {
+
+    // We want a modal thing
+
+    const keys = await getClient().keys();
+
+    // And then remove it
+
+    const promises = fields.map(({key, value}) => {
+        if(!keys.includes(key)) {
+            create(key, value);
+        } else {
+            getClient().update(key, value);
+        }
+    });
 
 };

--- a/src/components/KeyList/importCSV.js
+++ b/src/components/KeyList/importCSV.js
@@ -1,0 +1,56 @@
+import {getClient} from '../../services/BluzelleService'
+import Papa from 'papaparse';
+
+
+export const importCSV = () => {
+
+    const input = document.createElement('input');
+
+    input.type = 'file';
+
+
+    input.onchange = () => {
+
+        if(input.files.length === 0) {
+            return;
+        }
+
+        if(input.files.length > 1) {
+            alert('Please select only one file.')
+            return;
+        }
+
+        Papa.parse(input.files[0], {
+            complete: function(results) {
+
+                console.log("Errors from CSV input", results.errors);
+                console.log("CSV metadata", results.meta);
+
+
+                const table = results.data;
+
+                const notEmpty = cell => cell.length;
+
+
+                const filteredTable = table.map(row => row.filter(notEmpty));
+
+                const goodRows = filteredTable.filter(row => row.length >= 2);
+
+                const fields = goodRows.map(row => ({
+                    key: row[0],
+                    value: row[1]
+                }));
+
+
+                console.log(fields);
+
+            }
+        });
+
+
+    };
+
+
+    input.click();
+
+};

--- a/src/services/CRUDService.js
+++ b/src/services/CRUDService.js
@@ -1,6 +1,7 @@
-import {selectedKey, refreshKeys, tempKey} from '../components/KeyList';
+import {selectedKey, refreshKeys, tempKeys, keys} from '../components/KeyList';
 import {getClient} from './BluzelleService'
 import {observe} from 'mobx';
+
 
 export const activeValue = observable(undefined);
 
@@ -38,14 +39,15 @@ export const remove = () => new Promise(resolve => {
     const sk = selectedKey.get(); 
     selectedKey.set();
 
-    tempKey.set(sk);
+    tempKeys.push(sk);
 
     return getClient().delete(sk).then(() => {
         reload().then(resolve);
     })
     .catch(() => {
 
-        tempKey.set();
+        tempKeys.splice(tempKeys.indexOf(sk), 1);
+
         selectedKey.set(sk);
         
         alert('Failed to remove due to bluzelle network error.');
@@ -53,6 +55,35 @@ export const remove = () => new Promise(resolve => {
     });
 
 });
+
+
+export const create = (key, value) => {
+
+
+    keys.push(key);
+    tempKeys.push(key);
+
+    getClient().create(key, value).then(() => {
+        
+        while(tempKeys.includes(key)) {
+            tempKeys.splice(tempKeys.indexOf(key), 1);
+        }
+
+        refreshKeys();
+
+    }).catch(e => {
+
+        while(tempKeys.includes(key)) {
+            tempKeys.splice(tempKeys.indexOf(key), 1);
+        }
+        
+        keys.splice(keys.indexOf(key), 1);
+        
+        alert('Failed to create key due to bluzelle network error.'); 
+
+    });
+
+};
 
 
 export const rename = (oldKey, newKey) => new Promise(resolve => {


### PR DESCRIPTION
- The CSV upload button is on the database field panel.
- The CSV is interpreted row-by-row where the first non-empty cell is the key and the second non-empty cell is the value. Rows without two non-empty values are ignored.
- Will call a database update operation for existing keys and a database create operation for new keys.
- Better loading icons (to be completed in KEP-960 next week)

- This can be tested against bernoulli.bluzelle.com, but you can't click on any o the keys because the functionality is broken from quickread; you'd need to run a local swarm to get it all working.